### PR TITLE
Added build caching

### DIFF
--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -33,10 +33,10 @@
   </buildScan>
   <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>#{isFalse(env['CI'])}</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
     </remote>
   </buildCache>

--- a/pom.xml
+++ b/pom.xml
@@ -783,6 +783,26 @@
                         </dependency>
                     </dependencies>
                 </plugin>
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>develocity-maven-extension</artifactId>
+                    <configuration>
+                        <develocity>
+                            <normalization>
+                                <runtimeClassPath>
+                                    <propertiesNormalizations>
+                                        <propertiesNormalization>
+                                            <path>**/build.properties</path>
+                                            <ignoredProperties>
+                                                <ignore>Build-Timestamp</ignore>
+                                            </ignoredProperties>
+                                        </propertiesNormalization>
+                                    </propertiesNormalizations>
+                                </runtimeClassPath>
+                            </normalization>
+                        </develocity>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
This PR enables [build caching](https://docs.gradle.com/develocity/maven-build-cache/), which will improve both local and CI build times. 

After running local experiments, we can show that build time for `mvn clean install` with the cache enabled is reduced by ~36%(1m 41s) from [4m 23s](https://ge.solutions-team.gradle.com/s/dwf5yfacyisac#timeline) (no cache hits) down to [2m 48s](https://ge.solutions-team.gradle.com/s/csfai2gv43pf4#timeline) (with cache hits). 

This is related to issue https://github.com/eclipse-ee4j/jersey/pull/5863 and builds on PR https://github.com/eclipse-ee4j/jersey/issues/5861.